### PR TITLE
feat: add interactive mode with confirmation prompts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ tmp*
 CLAUDE.md
 tasks
 PrjDocs
+.vscode
 
 # Byte-compiled / optimized / DLL files
 __pycache__/

--- a/src/clipper/__init__.py
+++ b/src/clipper/__init__.py
@@ -22,6 +22,12 @@ def main() -> None:
         action="store_true",
         help="Show clipboard content and proposed changes without modifying clipboard",
     )
+    parser.add_argument(
+        "-i",
+        "--interactive",
+        action="store_true",
+        help="Ask for confirmation before converting text",
+    )
 
     args = parser.parse_args()
 
@@ -34,6 +40,8 @@ def main() -> None:
     engine = ProcessingEngine()
     if args.dry_run:
         success = engine.dry_run()
+    elif args.interactive:
+        success = engine.process_clipboard_interactive()
     else:
         success = engine.process_clipboard()
 


### PR DESCRIPTION
- Add --interactive/-i CLI flag
- Implement confirmation dialog before text conversion
- Show preview of proposed changes: "original" --> "converted"
- Handle graceful cancellation (Ctrl+C, empty input)
- Default to "No" for safety - requires explicit 'y'/'yes'
- Maintain consistent UX with existing dry-run mode