### PR TITLE
feat: add undo functionality to restore previous clipboard

### DIFF
--- a/src/clipper/__init__.py
+++ b/src/clipper/__init__.py
@@ -28,6 +28,12 @@ def main() -> None:
         action="store_true",
         help="Ask for confirmation before converting text",
     )
+    parser.add_argument(
+        "-u",
+        "--undo",
+        action="store_true",
+        help="Restore previous clipboard content",
+    )
 
     args = parser.parse_args()
 
@@ -40,6 +46,8 @@ def main() -> None:
     engine = ProcessingEngine()
     if args.dry_run:
         success = engine.dry_run()
+    elif args.undo:
+        success = engine.undo()
     elif args.interactive:
         success = engine.process_clipboard_interactive()
     else:

--- a/src/clipper/engine.py
+++ b/src/clipper/engine.py
@@ -14,7 +14,9 @@ class ProcessingEngine:
     def __init__(self) -> None:
         self.processors: List[BaseProcessor] = []
         self._register_default_processors()
-        self._undo_file = Path.home() / ".clipper_undo"
+        app_dir = Path.home() / ".clipper"
+        app_dir.mkdir(exist_ok=True)
+        self._undo_file = app_dir / "undo_state"
 
     def _truncate_text(self, text: str, max_chars: int = 10) -> str:
         """Truncate text to specified number of characters for preview."""

--- a/src/clipper/engine.py
+++ b/src/clipper/engine.py
@@ -1,6 +1,7 @@
 """Main processing engine for clipboard operations."""
 
 import sys
+from pathlib import Path
 from typing import List, Optional
 from .clipboard import get_clipboard_text, set_clipboard_text, ClipboardError
 from .processors.base import BaseProcessor
@@ -13,10 +14,28 @@ class ProcessingEngine:
     def __init__(self) -> None:
         self.processors: List[BaseProcessor] = []
         self._register_default_processors()
+        self._undo_file = Path.home() / ".clipper_undo"
 
     def _truncate_text(self, text: str, max_chars: int = 10) -> str:
         """Truncate text to specified number of characters for preview."""
         return text[:max_chars] if len(text) > max_chars else text
+
+    def _save_clipboard_for_undo(self, text: str) -> None:
+        """Save clipboard content for undo functionality."""
+        try:
+            self._undo_file.write_text(text, encoding="utf-8")
+        except Exception as e:
+            # Don't fail the main operation if undo save fails
+            print(f"Warning: Could not save undo state: {e}", file=sys.stderr)
+
+    def _load_clipboard_for_undo(self) -> Optional[str]:
+        """Load clipboard content for undo functionality."""
+        try:
+            if self._undo_file.exists():
+                return self._undo_file.read_text(encoding="utf-8")
+        except Exception:
+            pass
+        return None
 
     def _register_default_processors(self) -> None:
         """Register default processors."""
@@ -54,6 +73,9 @@ class ProcessingEngine:
                 text_preview = self._truncate_text(text)
                 print(f'no need to convert: "{text_preview}"', file=sys.stderr)
                 return True
+
+            # Save original text for undo before modifying clipboard
+            self._save_clipboard_for_undo(text)
 
             # Set processed text back to clipboard
             set_clipboard_text(processed_text)
@@ -141,6 +163,9 @@ class ProcessingEngine:
                 print("\nConversion cancelled.", file=sys.stderr)
                 return True
 
+            # Save original text for undo before modifying clipboard
+            self._save_clipboard_for_undo(text)
+
             # Set processed text back to clipboard
             set_clipboard_text(processed_text)
 
@@ -202,4 +227,34 @@ class ProcessingEngine:
             return False
         except Exception as e:
             print(f"Processing error: {e}", file=sys.stderr)
+            return False
+
+    def undo(self) -> bool:
+        """
+        Restore previous clipboard content.
+
+        Returns:
+            True if undo was successful, False otherwise.
+        """
+        try:
+            # Load previous clipboard content
+            previous_content = self._load_clipboard_for_undo()
+
+            if previous_content is None:
+                print("No previous clipboard content to restore.", file=sys.stderr)
+                return False
+
+            # Set previous content back to clipboard
+            set_clipboard_text(previous_content)
+
+            # Show success message with preview
+            restored_preview = self._truncate_text(previous_content)
+            print(f'restored: "{restored_preview}"', file=sys.stderr)
+            return True
+
+        except ClipboardError as e:
+            print(f"Clipboard error: {e}", file=sys.stderr)
+            return False
+        except Exception as e:
+            print(f"Undo error: {e}", file=sys.stderr)
             return False


### PR DESCRIPTION
- Add --undo/-u CLI flag
- Store original clipboard content before processing in ~/.clipper_undo file
- Implement restore mechanism with confirmation message
- Handle graceful error cases when no previous content exists
- Integrate undo save functionality with both normal and interactive modes
- Show helpful "restored:" message with text preview on successful undo